### PR TITLE
Re-auth if a new nonce is received

### DIFF
--- a/src/rpc/auth.ts
+++ b/src/rpc/auth.ts
@@ -88,10 +88,14 @@ export class JSONRPCClientWithAuthentication<ClientParams = void> extends JSONRP
         if (!this.password) {
           // abort authentication if we don't have a password
           return Promise.reject(new Error('Unauthorized'));
-        } else if (req.auth) {
-          // the request contained an authentication response but still fails with error 401, which means
-          // we have the wrong password
-          return Promise.reject(new Error('Invalid password'));
+        } else {
+          const errorJSON = JSON.parse(response.error.message);
+          // make sure auth has not expired, even though it shouldn't expire
+          if ((req.auth) && (errorJSON.nonce > 0) && (errorJSON.nonce === req.auth.nonce)) {
+            // the request contained an authentication response but still fails with error 401, which means
+            // we have the wrong password
+            return Promise.reject(new Error('Invalid password'));
+          }
         }
 
         try {


### PR DESCRIPTION
Fix https://github.com/alexryd/homebridge-shelly-ng/issues/37.
Fix https://github.com/alexryd/homebridge-shelly-ng/issues/53.
Fix https://github.com/alexryd/homebridge-shelly-ng/issues/59.

According to the [documentation](https://shelly-api-docs.shelly.cloud/gen2/General/Authentication), auth for websockets should never expire, but it seems it does. This checks if a new nonce was returned by the server. If so, don't fail but re-generate the auth.