### PR TITLE
Added support for Shelly Plus 1 Mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For the first generation, see [node-shellies](https://github.com/alexryd/node-sh
 ## Supported devices
 
 * [Shelly Plus 1 (Mini)](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1)
-* [Shelly Plus 1 PM](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1PM)
+* [Shelly Plus 1 PM (Mini)](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1PM)
 * [Shelly Plus 2 PM](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus2PM)
 * [Shelly Plus I4](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusI4)
 * [Shelly Plus Plug US](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlugUS)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For the first generation, see [node-shellies](https://github.com/alexryd/node-sh
 
 ## Supported devices
 
-* [Shelly Plus 1](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1)
+* [Shelly Plus 1 (Mini)](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1)
 * [Shelly Plus 1 PM](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1PM)
 * [Shelly Plus 2 PM](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus2PM)
 * [Shelly Plus I4](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusI4)

--- a/src/devices/shelly-plus-1-pm.ts
+++ b/src/devices/shelly-plus-1-pm.ts
@@ -46,3 +46,10 @@ export class ShellyPlus1PmUl extends ShellyPlus1Pm {
 }
 
 Device.registerClass(ShellyPlus1PmUl);
+
+export class ShellyPlus1PmMini extends ShellyPlus1Pm {
+  static readonly model: string = 'SNSW-001P8EU';
+}
+
+Device.registerClass(ShellyPlus1PmMini);
+

--- a/src/devices/shelly-plus-1.ts
+++ b/src/devices/shelly-plus-1.ts
@@ -46,3 +46,9 @@ export class ShellyPlus1Ul extends ShellyPlus1 {
 }
 
 Device.registerClass(ShellyPlus1Ul);
+
+export class ShellyPlus1Mini extends ShellyPlus1 {
+  static readonly model: string = 'SNSW-001X8EU';
+}
+
+Device.registerClass(ShellyPlus1Mini);


### PR DESCRIPTION
Shelly has released "mini" versions for some of their new generation products. They basically have the same functions as the normal ones, but using different model IDs. 