### PR TITLE
Add support for the Shelly Plus I4DC.

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -5,6 +5,7 @@ export * from './shelly-plus-1-pm';
 export * from './shelly-plus-2-pm';
 export * from './shelly-plus-ht';
 export * from './shelly-plus-i4';
+export * from './shelly-plus-i4dc';
 export * from './shelly-plus-plug-us';
 export * from './shelly-pro-1';
 export * from './shelly-pro-1-pm';

--- a/src/devices/shelly-plus-i4dc.ts
+++ b/src/devices/shelly-plus-i4dc.ts
@@ -9,7 +9,7 @@ import {
   WiFi,
 } from '../components';
 
-export class ShellyPlusI4 extends Device {
+export class ShellyPlusI4DC extends Device {
   static readonly model: string = 'SNSN-0D24X';
   static readonly modelName: string = 'Shelly Plus I4DC';
 

--- a/src/devices/shelly-plus-i4dc.ts
+++ b/src/devices/shelly-plus-i4dc.ts
@@ -1,0 +1,47 @@
+import { component, Device } from './base';
+import {
+  BluetoothLowEnergy,
+  Cloud,
+  Input,
+  Mqtt,
+  OutboundWebSocket,
+  Script,
+  WiFi,
+} from '../components';
+
+export class ShellyPlusI4 extends Device {
+  static readonly model: string = 'SNSN-0D24X';
+  static readonly modelName: string = 'Shelly Plus I4DC';
+
+  @component
+  readonly wifi = new WiFi(this);
+
+  @component
+  readonly bluetoothLowEnergy = new BluetoothLowEnergy(this);
+
+  @component
+  readonly cloud = new Cloud(this);
+
+  @component
+  readonly mqtt = new Mqtt(this);
+
+  @component
+  readonly outboundWebSocket = new OutboundWebSocket(this);
+
+  @component
+  readonly input0 = new Input(this, 0);
+
+  @component
+  readonly input1 = new Input(this, 1);
+
+  @component
+  readonly input2 = new Input(this, 2);
+
+  @component
+  readonly input3 = new Input(this, 3);
+
+  @component
+  readonly script = new Script(this);
+}
+
+Device.registerClass(ShellyPlusI4DC);


### PR DESCRIPTION
The Shelly Plus I4DC is the DC version of the Shelly Plus I4, this device has a different model number than the main Shelly Plus I4 (see below).

Shelly Plus I4 model number: SNSN-0024X
Shelly Plus I4DC model number: SNSN-0D24X

Output of [Shelly.GetDeviceInfo API](https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Shelly#shellygetdeviceinfo):
{"name":null,"id":"shellyplusi4-d4d4da7e1890","mac":"D4D4DA7E1890","slot":0,"model":"SNSN-0D24X","gen":2,"fw_id":"20231219-133933/1.1.0-g34b5d4f","ver":"1.1.0","app":"PlusI4","auth_en":false,"auth_domain":null}